### PR TITLE
Fix critical bugs including bcrypt sign in

### DIFF
--- a/src/middlewares/authMiddleware.js
+++ b/src/middlewares/authMiddleware.js
@@ -2,21 +2,15 @@ import { checkIfUserExists } from "../services/userService.js";
 import { verifyJWT } from "../utils/jwt.js";
 
 export const isAuthenticated = async(req, res, next) => {
-
-    
-    const token = req.headers?.authorization || req.cookies?.authToken;
-    // console.log("cookieheader:",token)
-
-    if (!token) {
-      return res.status(401).json({ success: false, token, message: "No authToken cookies found" });
+    // Prefer Authorization header with Bearer token; fallback to authToken cookie
+    let token = req.headers?.authorization || req.cookies?.authToken;
+    // Normalize Bearer token format
+    if (typeof token === 'string' && token.startsWith('Bearer ')) {
+        token = token.slice(7).trim();
     }
 
-
-    if(!token) {
-        return res.status(400).json({
-            success: false,
-            message: "Token is required. Login again!"
-        })
+    if (!token) {
+        return res.status(401).json({ success: false, message: "Token is required. Login again!" });
     }
 
     // Verify token
@@ -37,7 +31,7 @@ export const isAuthenticated = async(req, res, next) => {
         next();
 
     } catch (error) {
-        return res.status(400).json({
+        return res.status(401).json({
             success: false,
             message: "Invalid token"
         })

--- a/src/schema/user.js
+++ b/src/schema/user.js
@@ -58,9 +58,13 @@ const userSchema = new mongoose.Schema({
 userSchema.pre('save', function modifyPassword(next) {
     const user = this;
 
-    const salt = bcrypt.genSaltSync(9);
-    const hashedPassword = bcrypt.hashSync(user.password, salt)
+    // Only hash the password if it has been modified (or on new user)
+    if (!user.isModified('password')) {
+        return next();
+    }
 
+    const salt = bcrypt.genSaltSync(9);
+    const hashedPassword = bcrypt.hashSync(user.password, salt);
     user.password = hashedPassword;
 
     next();

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -32,7 +32,8 @@ export const signinUserService = async (userDetails) => {
             }
         }
 
-        const isPasswordValid = bcrypt.compareSync(userDetails?.password, user?.password);
+		// Use async compare to avoid blocking the event loop and ensure proper timing-safe comparison
+		const isPasswordValid = await bcrypt.compare(userDetails?.password || "", user?.password || "");
 
         if (!isPasswordValid) {
             throw {

--- a/src/validators/zodSigninSchema.js
+++ b/src/validators/zodSigninSchema.js
@@ -1,6 +1,6 @@
 import * as z from 'zod'
 
 export const zodSigninSchema = z.object({
-    email: z.email(),
-    password: z.string()
+    email: z.string().email({ message: 'Invalid email address' }),
+    password: z.string().min(1, { message: 'Password is required' })
 })

--- a/src/validators/zodSignupSchema.js
+++ b/src/validators/zodSignupSchema.js
@@ -1,7 +1,7 @@
 import * as z from "zod"
 
 export const zodSighupSchema = z.object({
-    username: z.string({ error: (iss) => iss.input === undefined ? "Username is required" : "Too small"}).min(5),
-    email: z.email(),
-    password: z.string().min(8)
+    username: z.string().min(5, { message: "Username must be at least 5 characters" }),
+    email: z.string().email({ message: "Invalid email address" }),
+    password: z.string().min(8, { message: "Password must be at least 8 characters" })
 })                     


### PR DESCRIPTION
Fix bcrypt sign-in logic, improve auth middleware token parsing, and correct Zod schema validations.

The previous bcrypt implementation re-hashed passwords on every user save, preventing subsequent logins, and used a synchronous comparison function (`bcrypt.compareSync`) which blocked the event loop. This PR guards the password hashing to only occur on modification and switches to the asynchronous `bcrypt.compare` for better performance and security.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7603848-5494-40e4-b980-c65301bf42f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c7603848-5494-40e4-b980-c65301bf42f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

